### PR TITLE
Replace File::Slurp with Path::Tiny

### DIFF
--- a/t/02-entry-iterator.t
+++ b/t/02-entry-iterator.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More 0.88 tests => 3;
 use PAUSE::Permissions;
-use File::Slurp;
+use Path::Tiny;
 
 #-----------------------------------------------------------------------
 # construct PAUSE::Permissions
@@ -35,7 +35,7 @@ while (my $entry = $iterator->next) {
                ."\n";
 }
 
-my $expected = read_file('t/06perms-mini.txt');
+my $expected = path('t/06perms-mini.txt')->slurp;
 $expected =~ s/\A.*\n\n//s;
 is($string, $expected, "rendered permissions");
 

--- a/t/03-module-iterator.t
+++ b/t/03-module-iterator.t
@@ -5,7 +5,6 @@ use warnings;
 
 use Test::More 0.88 tests => 3;
 use PAUSE::Permissions;
-use File::Slurp;
 
 #-----------------------------------------------------------------------
 # construct PAUSE::Permissions

--- a/t/04-live-module-iterator.t
+++ b/t/04-live-module-iterator.t
@@ -5,7 +5,6 @@ use warnings;
 
 use Test::More 0.88 tests => 3;
 use PAUSE::Permissions;
-use File::Slurp;
 
 #-----------------------------------------------------------------------
 # construct PAUSE::Permissions


### PR DESCRIPTION
Hi,

Thank you for your work on this module.
This short pull request replaces the use of File::Slurp with Path::Tiny within one test, and removes File::Slurp from tests where it was not being used.

See also

https://rt.cpan.org/Public/Bug/Display.html?id=95484