### PR TITLE
Don't "return sort @foo".

### DIFF
--- a/lib/PAUSE/Permissions/Module.pm
+++ b/lib/PAUSE/Permissions/Module.pm
@@ -42,7 +42,8 @@ sub co_maintainers
     push(@comaints, $self->f) if defined($self->m) && defined($self->f);
     push(@comaints, @{ $self->c }) if defined($self->c);
 
-    return sort @comaints;
+    @comaints = sort @comaints;
+    return @comaints;
 }
 
 sub all_maintainers
@@ -54,7 +55,8 @@ sub all_maintainers
     push(@all, $self->f)      if defined($self->f);
     push(@all, @{ $self->c }) if defined($self->c);
 
-    return sort @all;
+    @all = sort @all;
+    return @all;
 }
 
 1;


### PR DESCRIPTION
See
https://metacpan.org/pod/distribution/Perl-Critic/lib/Perl/Critic/Policy/Subroutines/ProhibitReturnSort.pm

This bit me today:

```
    while ( my $perms = $iterator->next_module ) {
        $bulk_helper->update(
            {
                id  => $perms->name,
                doc => {
                    $perms->co_maintainers
                    ? ( co_maintainers => $perms->co_maintainers )
                    : (),
                    module_name => $perms->name,
                    owner       => $perms->owner,
                },
                doc_as_upsert => 1,
            }
        );
    }
```

If you `return sort @foo` in `co_maintainers()` then `$perms->co_maintainers` will never return true in the ternary above.  This was pretty confusing.  :)